### PR TITLE
Set the base python version to 3.9 and above

### DIFF
--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
         run: pre-commit run --all-files --show-diff-on-failure
 
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.10.0
     hooks:
       - id: black

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.9
 include_package_data = True
 package_dir =
     = .


### PR DESCRIPTION
# Change
Python 3.6 was the previous base and it is now EOL. Anyone needing to use blaster with < 3.9 will need to install version 0.5.0.

Closes #50 